### PR TITLE
Fix Title Bar Buttons

### DIFF
--- a/configuration-frontend/sass/main.scss
+++ b/configuration-frontend/sass/main.scss
@@ -31,6 +31,7 @@ body {
   background: #222222;
   color: #ffffff;
   position: relative;
+  -webkit-app-region: drag;
   .navigation {
     position: absolute;
     left: 0;
@@ -64,6 +65,7 @@ body {
 .header .btn, .header .btn:hover, .header .btn:focus {
   background: #222;
   outline: none;
+  -webkit-app-region: no-drag;
 }
 
 .header .btn:hover {

--- a/configuration-frontend/templates/directives/header.html
+++ b/configuration-frontend/templates/directives/header.html
@@ -1,4 +1,4 @@
-<div class="header" style="-webkit-app-region: drag">
+<div class="header">
     <div class="navigation">
         <!--<button class="btn btn-primary" ui-sref="home">-->
             <!--<i class="fa fa-home"></i>-->


### PR DESCRIPTION
Fix the title bar buttons and move the inline style to the stylesheet.

Before adding no-drag, you were unable to hover over or click them.