### PR TITLE
Add Ability to Drag Overlay Elements

### DIFF
--- a/overlay-frontend/css/main.css
+++ b/overlay-frontend/css/main.css
@@ -7,6 +7,10 @@
     user-select: none;
 }
 
+html, body {
+    height: 100%;
+}
+
 body {
     margin: 0;
     padding: 0;
@@ -14,6 +18,11 @@ body {
     font-family: HelveticaNeue-Light, Helvetica, Arial;
     overflow: hidden;
     color: #111111;
+    -webkit-app-region: drag;
+}
+
+.widget {
+    -webkit-app-region: no-drag;
 }
 
 header {
@@ -216,11 +225,18 @@ highlight {
     font-weight: bold;
 }
 
-#chat {
+.chat {
     color: #FFF;
     position: absolute;
     right: 5px;
     top: 206px;
+    font-size: 12px;
+    overflow: hidden;
+}
+
+#chat {
+    color: #FFF;
+    position: relative;
     max-height: 198px;
     width: 267px;
     font-size: 12px;
@@ -229,7 +245,7 @@ highlight {
     border: 3px solid #e7196e;
     z-index: 10;
     transition: all 200ms ease-out;
-}
+ }
 
 #chat .line-container {
     background: #222;

--- a/overlay-frontend/index.html
+++ b/overlay-frontend/index.html
@@ -20,6 +20,7 @@
     <script src="js/app.js"></script>
     <script src="../configuration-frontend/js/services/Tick.js"></script>
     <script src="js/controller/OverlayController.js"></script>
+    <script src="js/directives/ngDrag.js"></script>
     <script src="js/directives/chat.js"></script>
     <script src="js/directives/followerAlert.js"></script>
     <script src="js/directives/message.js"></script>
@@ -27,7 +28,6 @@
     <!-- endinject -->
 </head>
 <body ng-app="TwitchOverlay">
-<header></header>
 <div class="content" ui-view>
 
 </div>

--- a/overlay-frontend/js/controller/OverlayController.js
+++ b/overlay-frontend/js/controller/OverlayController.js
@@ -58,6 +58,10 @@ TwitchOverlay.controller('OverlayController', ['$scope', '$rootScope', function 
         });
     }
 
+    $scope.dragOptions = {
+        container: 'body'
+    };
+
     $scope.showDevTools = function() {
         win.showDevTools();
     };

--- a/overlay-frontend/js/directives/chat.js
+++ b/overlay-frontend/js/directives/chat.js
@@ -4,6 +4,7 @@ TwitchOverlay.directive('chat', [function() {
         scope: {
             chatData: '='
         },
+        replace: true,
         templateUrl: 'templates/directives/chat.html',
         link: function($scope, elem, attrs) {
 
@@ -23,12 +24,12 @@ TwitchOverlay.directive('chat', [function() {
             };
 
             window.setInterval(function() {
-                var markup = $(elem).find('.line-container');
-                var container = $(elem).find('#chat');
+                var markup = elem.find('.line-container');
+
                 if (markup.height() < _maxHeight) {
-                    container.height(markup.height() + 6);
+                    elem.height(markup.height() + 6);
                 } else {
-                    container.height(_maxHeight);
+                    elem.height(_maxHeight);
                 }
             }, 100);
         }

--- a/overlay-frontend/js/directives/ngDrag.js
+++ b/overlay-frontend/js/directives/ngDrag.js
@@ -1,0 +1,78 @@
+TwitchOverlay.directive('ngDrag', function ($document) {
+    return {
+        restrict: 'A',
+        scope: {
+            dragOptions: '=ngDrag'
+        },
+        link: function (scope, elem, attr) {
+            var startX, startY, x = 0, y = 0,
+                start, stop, drag, container;
+
+            var width = elem[0].offsetWidth,
+                height = elem[0].offsetHeight;
+
+            // Obtain drag options
+            if (scope.dragOptions) {
+                start = scope.dragOptions.start;
+                drag = scope.dragOptions.drag;
+                stop = scope.dragOptions.stop;
+
+                var id = scope.dragOptions.container;
+
+                if (id) {
+                    container = $(id)[0].getBoundingClientRect();
+                }
+            }
+
+            // Set cursor to the move icon
+            elem.css('cursor', 'move');
+
+            // Bind mousedown event
+            elem.on('mousedown', function (e) {
+                e.preventDefault();
+                startX = e.clientX - elem[0].offsetLeft;
+                startY = e.clientY - elem[0].offsetTop;
+                $document.on('mousemove', mousemove);
+                $document.on('mouseup', mouseup);
+                if (start) start(e);
+            });
+
+            // Handle drag event
+            function mousemove(e) {
+                y = e.clientY - startY;
+                x = e.clientX - startX;
+                setPosition();
+                if (drag) drag(e);
+            }
+
+            // Unbind drag events
+            function mouseup(e) {
+                $document.unbind('mousemove', mousemove);
+                $document.unbind('mouseup', mouseup);
+                if (stop) stop(e);
+            }
+
+            // Move element, within container if provided
+            function setPosition() {
+                if (container) {
+                    if (x < container.left) {
+                        x = container.left;
+                    } else if (x > container.right - width) {
+                        x = container.right - width;
+                    }
+                    if (y < container.top) {
+                        y = container.top;
+                    } else if (y > container.bottom - height) {
+                        y = container.bottom - height;
+                    }
+                }
+
+                elem.css({
+                    top: y + 'px',
+                    left: x + 'px'
+                });
+            }
+        }
+    }
+
+});

--- a/overlay-frontend/templates/directives/chat.html
+++ b/overlay-frontend/templates/directives/chat.html
@@ -1,4 +1,4 @@
-<div class="chat" id="chat" ng-show="showChatFrame()">
+<div id="chat" ng-show="showChatFrame()">
     <div class="line-container">
         <div class="line" ng-repeat="line in chatData" ng-show="showLine(line.ts)">
             <span class="time">{{line.ts | date:'HH:mm'}}</span>

--- a/overlay-frontend/templates/home.html
+++ b/overlay-frontend/templates/home.html
@@ -1,39 +1,46 @@
-<div class="logo"></div>
+<div class="logo widget" ng-drag="dragOptions"></div>
 
-<header style="-webkit-app-region: drag">
+<header class="widget" ng-drag="dragOptions">
     <span class="topic-container">
         <span class="topic"><i class="fa fa-gamepad"></i> {{data.topic}} <i class="fa fa-gamepad"></i></span>
     </span>
 </header>
 
-<div class="cam"></div>
+<div class="cam widget" ng-drag="dragOptions"></div>
 
 <follower-alert followers="data.follower.latestFollowers"></follower-alert>
-<chat chat-data="data.chat"></chat>
 
-<div class="sidebar"></div>
-<div class="followers">
+<div class="chat widget" ng-drag="dragOptions">
+    <chat chat-data="data.chat"></chat>
+</div>
+
+<div class="followers widget" ng-drag="dragOptions">
     <i class="fa fa-users"></i>
     Followers:
     <span class="current-followers">{{data.follower.followerCurrent}}</span>
     <span ng-show="data.followerTarget > 0"> / <span class="target-followers">{{data.followerTarget}}</span></span>
 </div>
-<div class="newest-follower-container">
+
+<div class="newest-follower-container widget" ng-drag="dragOptions">
     <i class="fa fa-heart-o"></i>
     Latest follower: <span class="newest-follower">{{data.follower.followerNewest.name}}</span>
     <i class="fa fa-heart-o"></i>
 </div>
-<div class="schimmel-count-container hide">
+
+<div class="schimmel-count-container widget hide" ng-drag="dragOptions">
     <i class="fa fa-bar-chart"></i>
     Schimmel Count: <span class="schimmel-count"></span>
 </div>
+
 <footer>
-    <div class="raffle" ng-show="data.subline">
+    <div class="raffle widget" ng-show="data.subline" ng-drag="dragOptions">
         <i class="fa fa-star-o"></i>
         {{data.subline}}
     </div>
 </footer>
+
 <div class="backdrop" ng-class="{loaded: loaded}"></div>
+
 <div class="connection-window" ng-show="showConnectionWindow">
     <form>
         <div class="form-group">
@@ -47,4 +54,5 @@
         <button type="submit" class="btn btn-default" ng-click="connect()">connect</button>
     </form>
 </div>
-<div class="open-debug" ng-click="showDevTools()"></div>
+
+<div class="open-debug widget" ng-click="showDevTools()"></div>


### PR DESCRIPTION
Instead of editing the styles to move things around, this allows you to simply drag the elements into place on the overlay. 

It could be a good start for widgetizing them; which could later allow them to be dynamically added/removed, resized, styled, etc. Their positions are not persisted, that can be an item on the todo list. :)

(This also makes the body the drag-handle for the overlay screen to prevent a header-based handle from interfering with the dragging of widgets)